### PR TITLE
Add logger factory and custom splunk text formatter

### DIFF
--- a/Serilog.Builder.Tests/LoggerBuilderTests.cs
+++ b/Serilog.Builder.Tests/LoggerBuilderTests.cs
@@ -1,5 +1,6 @@
 using Serilog.Builder.Models;
 using Serilog.Events;
+using Serilog.Sinks.Splunk.CustomFormatter;
 using System;
 using System.IO;
 using Xunit;
@@ -233,6 +234,7 @@ namespace Serilog.Builder.Tests
             Assert.True(builder.OutputConfiguration.Splunk.Enabled);
             Assert.NotNull(builder.OutputConfiguration.Splunk.Options.Url);
             Assert.Null(builder.OutputConfiguration.Splunk.Options.Token);
+            Assert.Null(builder.OutputConfiguration.Splunk.Options.TextFormatter);
         }
 
         [Fact]
@@ -248,6 +250,7 @@ namespace Serilog.Builder.Tests
             Assert.True(builder.OutputConfiguration.Splunk.Enabled);
             Assert.NotNull(builder.OutputConfiguration.Splunk.Options.Url);
             Assert.NotNull(builder.OutputConfiguration.Splunk.Options.Token);
+            Assert.Null(builder.OutputConfiguration.Splunk.Options.TextFormatter);
         }
 
         [Fact]
@@ -279,6 +282,7 @@ namespace Serilog.Builder.Tests
             Assert.Equal("http://www.google.com", builder.OutputConfiguration.Splunk.Options.Url);
             Assert.NotNull(builder.OutputConfiguration.Splunk.Options.Token);
             Assert.Equal("XXXXX", builder.OutputConfiguration.Splunk.Options.Token);
+            Assert.Null(builder.OutputConfiguration.Splunk.Options.TextFormatter);
         }
 
         [Fact]
@@ -1031,5 +1035,46 @@ namespace Serilog.Builder.Tests
             // assert
             Assert.NotNull(logger);
         }
+
+        [Fact]
+        public void Build_Basics_Logger_With_Json_Formatter()
+        {
+            // arrage
+            LoggerBuilder builder = new LoggerBuilder();
+
+            SeqOptions seqOptions = new SeqOptions
+            {
+                Url = "http://localhost",
+                ApiKey = "123456"
+            };
+
+            SplunkOptions splunkOptions = new SplunkOptions
+            {
+                Url = "http://localhost",
+                Token = "123456",
+                Index = "my.index"
+            };
+
+            var splunkSettings = new SplunkLogSettings()
+            {
+                ServerURL = splunkOptions.Url,
+                Token = splunkOptions.Token,
+                Index = splunkOptions.Index
+            };
+
+            splunkOptions.TextFormatter = new SplunkJsonFormatter(splunkSettings);
+
+            Log.Logger = builder
+                .UseSuggestedSetting("MyDomain", "MyApplication")
+                .SetupSeq(seqOptions)
+                .SetupSplunk(splunkOptions)
+                .BuildLogger();
+
+            // act
+            var logger = builder.BuildLogger();
+
+            // assert
+            Assert.NotNull(logger);
+        }        
     }
 }

--- a/Serilog.Builder.Tests/LoggerFactoryTests.cs
+++ b/Serilog.Builder.Tests/LoggerFactoryTests.cs
@@ -1,0 +1,197 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using Serilog.Builder.Factory;
+using Serilog.Builder.Models;
+using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Serilog.Builder.Tests
+{
+    public class LoggerFactoryTests : IDisposable
+    {
+        private TestOutputHelper TestOutputHelper { get; set; }
+
+        private readonly Mock<IOptions<LoggerOptions>> _loggerOptions = new Mock<IOptions<LoggerOptions>>();
+        private readonly Mock<IOptions<SeqOptions>> _seqOptions = new Mock<IOptions<SeqOptions>>();
+        private readonly Mock<IOptions<SplunkOptions>> _splunkOptions = new Mock<IOptions<SplunkOptions>>();
+        private readonly Mock<IOptions<GoogleCloudLoggingOptions>> _googleCloudLoggingOptions = new Mock<IOptions<GoogleCloudLoggingOptions>>();
+
+        public LoggerFactoryTests(ITestOutputHelper testOutputHelper)
+        {
+            this.TestOutputHelper = testOutputHelper as TestOutputHelper;
+
+            var faker = new Bogus.Faker();
+
+            var loggerOptions = new LoggerOptions()
+            {
+                Domain = faker.Lorem.Word(),
+                Application = faker.Lorem.Word()
+            };
+
+            _loggerOptions.Setup(x => x.Value).Returns(loggerOptions);
+
+            var seqOptions = new SeqOptions
+            {
+                Enabled = faker.Random.Bool(),
+                MinimumLevel = faker.PickRandom<LogEventLevel>(),
+                Url = faker.Internet.Url(),
+                ApiKey = faker.Random.AlphaNumeric(8)
+            };
+
+            _seqOptions.Setup(x => x.Value).Returns(seqOptions);
+
+            var splunkOptions = new SplunkOptions
+            {
+                Enabled = faker.Random.Bool(),
+                MinimumLevel = faker.PickRandom<LogEventLevel>(),
+                Index = faker.Random.AlphaNumeric(8),
+                Application = faker.Lorem.Word(),
+                ProcessName = faker.Lorem.Word(),
+                Company = faker.Company.CompanyName(),
+                ProductVersion = faker.Random.Int(1, 10).ToString(),
+                Url = faker.Internet.Url(),
+                SourceType = faker.Lorem.Word(),
+                Token = faker.Random.AlphaNumeric(8)
+            };
+
+            _splunkOptions.Setup(x => x.Value).Returns(splunkOptions);
+
+            var gcpOptions = new GoogleCloudLoggingOptions
+            {
+                Enabled = faker.Random.Bool(),
+                ProjectId = faker.Random.AlphaNumeric(8),
+                CertificatePath = faker.System.FilePath(),
+                UseJsonOutput = faker.Random.Bool(),
+                ResourceType = faker.Random.AlphaNumeric(8),
+                Labels = new Dictionary<string, string>(),
+                ResourceLabels = new Dictionary<string, string>()
+            };
+
+            _googleCloudLoggingOptions.Setup(x => x.Value).Returns(gcpOptions);
+        }
+
+        [Fact]
+        public void Construct_Using_Default()
+        {
+            // arrage & act
+            ILoggerFactory loggerFactory = new LoggerFactory(_loggerOptions.Object, _seqOptions.Object,
+                _splunkOptions.Object, _googleCloudLoggingOptions.Object);
+
+            // assert
+            Assert.IsType<Core.Logger>(Log.Logger);
+        }
+
+        [Fact]
+        public void Return_Single_Instance()
+        {
+            // arrage & act
+            ILoggerFactory loggerFactory = new LoggerFactory(_loggerOptions.Object, _seqOptions.Object,
+                _splunkOptions.Object, _googleCloudLoggingOptions.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Create();
+            ILoggerDefault loggerDefault2 = loggerFactory.Create();
+
+            // assert
+            Assert.Same(loggerDefault, loggerDefault2);
+        }
+
+        [Fact]
+        public void Verify_InfoAsync()
+        {
+            // arrage & act
+            Mock<ILoggerDefault> loggerDefaultExpected = new Mock<ILoggerDefault>();
+            loggerDefaultExpected.Setup(x => x.InfoAsync(It.IsAny<string>()));
+
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.Create()).Returns(loggerDefaultExpected.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Object.Create();
+            
+            loggerDefault.InfoAsync("message");
+
+            // assert
+            loggerDefaultExpected.Verify(x => x.InfoAsync(It.IsAny<string>()));            
+        }
+
+        [Fact]
+        public void Verify_WarningAsync()
+        {
+            // arrage & act
+            Mock<ILoggerDefault> loggerDefaultExpected = new Mock<ILoggerDefault>();
+            loggerDefaultExpected.Setup(x => x.WarningAsync(It.IsAny<string>()));
+
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.Create()).Returns(loggerDefaultExpected.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Object.Create();
+
+            loggerDefault.WarningAsync("message");
+
+            // assert
+            loggerDefaultExpected.Verify(x => x.WarningAsync(It.IsAny<string>()));
+        }
+
+        [Fact]
+        public void Verify_WarningAsync_With_Exception()
+        {
+            // arrage & act
+            Mock<ILoggerDefault> loggerDefaultExpected = new Mock<ILoggerDefault>();
+            loggerDefaultExpected.Setup(x => x.WarningAsync(It.IsAny<string>(), It.IsAny<Exception>()));
+
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.Create()).Returns(loggerDefaultExpected.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Object.Create();
+
+            loggerDefault.WarningAsync("message", new Exception());
+
+            // assert
+            loggerDefaultExpected.Verify(x => x.WarningAsync(It.IsAny<string>(), It.IsAny<Exception>()));
+        }
+
+        [Fact]
+        public void Verify_ErrorAsync()
+        {
+            // arrage & act
+            Mock<ILoggerDefault> loggerDefaultExpected = new Mock<ILoggerDefault>();
+            loggerDefaultExpected.Setup(x => x.ErrorAsync(It.IsAny<string>()));
+
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.Create()).Returns(loggerDefaultExpected.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Object.Create();
+
+            loggerDefault.ErrorAsync("message");
+
+            // assert
+            loggerDefaultExpected.Verify(x => x.ErrorAsync(It.IsAny<string>()));
+        }
+
+        [Fact]
+        public void Verify_ErrorAsync_With_Exception()
+        {
+            // arrage & act
+            Mock<ILoggerDefault> loggerDefaultExpected = new Mock<ILoggerDefault>();
+            loggerDefaultExpected.Setup(x => x.ErrorAsync(It.IsAny<string>(), It.IsAny<Exception>()));
+
+            Mock<ILoggerFactory> loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.Create()).Returns(loggerDefaultExpected.Object);
+
+            ILoggerDefault loggerDefault = loggerFactory.Object.Create();
+
+            loggerDefault.ErrorAsync("message", new Exception());
+
+            // assert
+            loggerDefaultExpected.Verify(x => x.ErrorAsync(It.IsAny<string>(), It.IsAny<Exception>()));
+        }
+
+        public void Dispose()
+        {
+            LoggerFactory.Flush();
+        }
+    }
+}

--- a/Serilog.Builder.Tests/Serilog.Builder.Tests.csproj
+++ b/Serilog.Builder.Tests/Serilog.Builder.Tests.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="26.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Serilog.Sinks.XunitTestOutput" Version="1.0.14" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Serilog.Builder/Factory/ILoggerDefault.cs
+++ b/Serilog.Builder/Factory/ILoggerDefault.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Serilog.Builder.Factory
+{
+    /// <summary>
+    /// Serilog Logger default interface
+    /// </summary>
+    public interface ILoggerDefault
+    {
+        /// <summary>
+        /// Log async with information level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        Task InfoAsync(string message);
+
+        /// <summary>
+        /// Log async with warning level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        Task WarningAsync(string message);
+
+        /// <summary>
+        /// Log async with warning level with exception
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="ex">Exception</param>
+        /// <returns></returns>
+        Task WarningAsync(string message, Exception ex);
+
+        /// <summary>
+        /// Log async with error level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        Task ErrorAsync(string message);
+
+        /// <summary>
+        /// Log async with error level with exception
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="ex">Exception</param>
+        /// <returns></returns>
+        Task ErrorAsync(string message, Exception ex);
+    }
+}

--- a/Serilog.Builder/Factory/ILoggerFactory.cs
+++ b/Serilog.Builder/Factory/ILoggerFactory.cs
@@ -1,0 +1,14 @@
+﻿namespace Serilog.Builder.Factory
+{
+    /// <summary>
+    /// Serilog Logger factory interface
+    /// </summary>
+    public interface ILoggerFactory
+    {
+        /// <summary>
+        /// Create logger default
+        /// </summary>
+        /// <returns></returns>
+        ILoggerDefault Create();
+    }
+}

--- a/Serilog.Builder/Factory/LoggerDefault.cs
+++ b/Serilog.Builder/Factory/LoggerDefault.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Serilog.Builder.Factory
+{
+    /// <summary>
+    /// Serilog Logger default class
+    /// </summary>
+    public class LoggerDefault : ILoggerDefault
+    {
+        /// <summary>
+        /// Log async with information level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        public async Task InfoAsync(string message)
+        {
+            await Task.Run(() => Log.Information(message));
+        }
+
+        /// <summary>
+        /// Log async with warning level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        public async Task WarningAsync(string message)
+        {
+            await Task.Run(() => Log.Warning(message));
+        }
+
+        /// <summary>
+        /// Log async with warning level with exception
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="ex">Exception</param>
+        /// <returns></returns>
+        public async Task WarningAsync(string message, Exception ex)
+        {
+            await Task.Run(() => Log.Warning(ex, message));
+        }
+
+        /// <summary>
+        /// Log async with error level
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <returns></returns>
+        public async Task ErrorAsync(string message)
+        {
+            await Task.Run(() => Log.Error(message));
+        }
+
+        /// <summary>
+        /// Log async with error level with exception
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="ex">Exception</param>
+        /// <returns></returns>
+        public async Task ErrorAsync(string message, Exception ex)
+        {
+            await Task.Run(() => Log.Error(ex, message));
+        }
+    }
+}

--- a/Serilog.Builder/Factory/LoggerFactory.cs
+++ b/Serilog.Builder/Factory/LoggerFactory.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Options;
+using Serilog.Builder.Models;
+
+namespace Serilog.Builder.Factory
+{
+    /// <summary>
+    /// Serilog Logger factory class
+    /// </summary>
+    public class LoggerFactory : ILoggerFactory
+    {
+        /// <summary>
+        /// Logger default instance
+        /// </summary>
+        private static ILoggerDefault _loggerDefault;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="loggerOptions">Logger Options</param>
+        /// <param name="seqOptions">Seq Options</param>
+        /// <param name="splunkOptions">Splunk Options</param>
+        /// <param name="gcpOptions">Google Cloud Logging Options </param>
+        public LoggerFactory(
+            IOptions<LoggerOptions> loggerOptions,
+            IOptions<SeqOptions> seqOptions,
+            IOptions<SplunkOptions> splunkOptions,
+            IOptions<GoogleCloudLoggingOptions> gcpOptions)
+        {
+            LoggerBuilder builder = new LoggerBuilder();
+
+            var logger = loggerOptions.Value;
+
+            Log.Logger = builder
+            .UseSuggestedSetting(logger.Domain, logger.Application)
+            .SetupSeq(seqOptions.Value)
+            .SetupSplunk(splunkOptions.Value)
+            .SetupGoogleCloudLogging(gcpOptions.Value)
+            .BuildLogger();
+        }
+
+        /// <summary>
+        /// Create logger default
+        /// </summary>
+        /// <returns></returns>
+        public ILoggerDefault Create()
+        {
+            if (_loggerDefault == null)
+                _loggerDefault = new LoggerDefault();
+
+            return _loggerDefault;
+        }
+
+        /// <summary>
+        /// Flush log
+        /// </summary>
+        public static void Flush()
+        {
+            Log.CloseAndFlush();
+        }
+    }
+}

--- a/Serilog.Builder/LoggerBuilder.Splunk.cs
+++ b/Serilog.Builder/LoggerBuilder.Splunk.cs
@@ -114,7 +114,7 @@ namespace Serilog.Builder
         /// <returns></returns>
         private ITextFormatter GetSplunkLogFormatter(SplunkLogSettings splunkLogSettings)
         {
-            var textFormatter = this.OutputConfiguration.Splunk.Options.textFormatter;
+            var textFormatter = this.OutputConfiguration.Splunk.Options.TextFormatter;
 
             if (textFormatter == null) return new SplunkJsonFormatter(splunkLogSettings);
 

--- a/Serilog.Builder/LoggerBuilder.Splunk.cs
+++ b/Serilog.Builder/LoggerBuilder.Splunk.cs
@@ -1,4 +1,5 @@
 ﻿using Serilog.Builder.Models;
+using Serilog.Formatting;
 using Serilog.Sinks.Splunk.CustomFormatter;
 using System;
 
@@ -19,7 +20,7 @@ namespace Serilog.Builder
             {
                 var logLevel = this.OutputConfiguration.Splunk.Options.MinimumLevel ?? this.OutputConfiguration.MinimumLevel;
                 var splunkSettings = this.GetSplunkLogSettings();
-                var splunkFormatter = new SplunkJsonFormatter(splunkSettings);
+                var splunkFormatter = this.GetSplunkLogFormatter(splunkSettings);
 
                 logger.WriteTo.EventCollector(splunkSettings.ServerURL, splunkSettings.Token, jsonFormatter: splunkFormatter, restrictedToMinimumLevel: logLevel);
             }
@@ -66,7 +67,7 @@ namespace Serilog.Builder
                 ?? throw new ArgumentNullException(nameof(options));
 
             if (string.IsNullOrWhiteSpace(options.Url) == true && options.Enabled == true)
-            { 
+            {
                 throw new ArgumentNullException(nameof(options.Url));
             }
 
@@ -104,6 +105,20 @@ namespace Serilog.Builder
             };
 
             return splunkLogSettings;
+        }
+
+        /// <summary>
+        /// Get custom or default Splunk log formatter
+        /// </summary>
+        /// <param name="splunkLogSettings">Splunk log settings</param>
+        /// <returns></returns>
+        private ITextFormatter GetSplunkLogFormatter(SplunkLogSettings splunkLogSettings)
+        {
+            var textFormatter = this.OutputConfiguration.Splunk.Options.textFormatter;
+
+            if (textFormatter == null) return new SplunkJsonFormatter(splunkLogSettings);
+
+            return textFormatter;
         }
     }
 }

--- a/Serilog.Builder/Models/LoggerOptions.cs
+++ b/Serilog.Builder/Models/LoggerOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Serilog.Builder.Models
+{
+    /// <summary>
+    /// Logger options class
+    /// </summary>
+    public class LoggerOptions
+    {
+        /// <summary>
+        /// Application
+        /// </summary>
+        public string Application { get; set; }
+
+        /// <summary>
+        /// Domain
+        /// </summary>
+        public string Domain { get; set; }
+    }
+}

--- a/Serilog.Builder/Models/SplunkOptions.cs
+++ b/Serilog.Builder/Models/SplunkOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Serilog.Events;
+using Serilog.Formatting;
 
 namespace Serilog.Builder.Models
 {
@@ -56,5 +57,10 @@ namespace Serilog.Builder.Models
         /// Access token
         /// </summary>
         public string Token { get; set; }
+
+        /// <summary>
+        /// Custom Text Formatter
+        /// </summary>
+        public ITextFormatter textFormatter { get; set; }
     }
 }

--- a/Serilog.Builder/Models/SplunkOptions.cs
+++ b/Serilog.Builder/Models/SplunkOptions.cs
@@ -61,6 +61,6 @@ namespace Serilog.Builder.Models
         /// <summary>
         /// Custom Text Formatter
         /// </summary>
-        public ITextFormatter textFormatter { get; set; }
+        public ITextFormatter TextFormatter { get; set; }
     }
 }


### PR DESCRIPTION
[feature] Add logger factory and custom splunk text formatter

### Status

READY

### Whats?

Add logger factory and custom splunk text formatter

### Why?

To decrease duplicated code in applications that use the serilog builder, ensure that only one instance of logger is been used and allow the use of another splunk text formatter.

### How?

Adding new classes, changing the method that get the splunk formatter, installing moq and bogus to mock some tests.

### Definition of Done:
- [X] Increases API documentation
- [ ] Implements integration tests
- [X] Implements unit tests
- [X] Is there appropriate logging included?
- [X] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
