### PR TITLE
[Feature] Add LAPI configuration logger

### DIFF
--- a/Serilog.Builder.Tests/LoggerInitializeTests.cs
+++ b/Serilog.Builder.Tests/LoggerInitializeTests.cs
@@ -17,6 +17,7 @@ namespace Serilog.Builder.Tests
                 Console = new ConsoleOptions(),
                 Seq = new SeqOptions(),
                 Splunk = new SplunkOptions(),
+                Lapi = new LapiOptions(),
                 NewRelic = new NewRelicOptions(),
                 DataDog = new DataDogOptions()
             };
@@ -28,6 +29,7 @@ namespace Serilog.Builder.Tests
             Assert.False(loggerOptions.Console.Enabled);
             Assert.False(loggerOptions.Seq.Enabled);
             Assert.False(loggerOptions.Splunk.Enabled);
+            Assert.False(loggerOptions.Lapi.Enabled);
             Assert.False(loggerOptions.NewRelic.Enabled);
             Assert.False(loggerOptions.DataDog.Enabled);
         }
@@ -44,6 +46,7 @@ namespace Serilog.Builder.Tests
                 Console = new ConsoleOptions(),
                 Seq = new SeqOptions(),
                 Splunk = new SplunkOptions(),
+                Lapi = new LapiOptions(),
                 NewRelic = new NewRelicOptions(),
                 DataDog = new DataDogOptions()
             };
@@ -55,6 +58,7 @@ namespace Serilog.Builder.Tests
             Assert.False(loggerOptions.Console.Enabled);
             Assert.False(loggerOptions.Seq.Enabled);
             Assert.False(loggerOptions.Splunk.Enabled);
+            Assert.False(loggerOptions.Lapi.Enabled);
             Assert.False(loggerOptions.NewRelic.Enabled);
             Assert.False(loggerOptions.DataDog.Enabled);
         }

--- a/Serilog.Builder/CustomFormatters/LapiJsonFormatter.cs
+++ b/Serilog.Builder/CustomFormatters/LapiJsonFormatter.cs
@@ -1,0 +1,142 @@
+﻿using Serilog.Builder.Models.Mappers;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace Serilog.Builder.CustomFormatters
+{
+    public class LapiJsonFormatter : ITextFormatter
+    {
+        private const char SEPARATOR = ':';
+        private const string DEFAULT_DELIMITER = ",";
+        private readonly string _index;
+        private static readonly JsonValueFormatter _valueFormatter = new JsonValueFormatter();
+
+        public LapiJsonFormatter(string index)
+        {
+            if (string.IsNullOrWhiteSpace(index))
+                throw new ArgumentNullException(nameof(index));
+
+            _index = index;
+        }
+
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent is null)
+                throw new ArgumentNullException(nameof(logEvent));
+
+            if (output is null)
+                throw new ArgumentNullException(nameof(output));
+
+            var lapiMapper = ArrangeLogData(logEvent, _index);
+
+            WriteAndFormatPropertiesToSplunk(logEvent, lapiMapper, output);
+            WriteDefaultSuffixPropertiesToSplunk(lapiMapper, output);
+        }
+
+        private static LogLapiMapper ArrangeLogData(LogEvent logEvent, string index)
+        {
+            var message = logEvent.RenderMessage();
+
+            var lapiMapper = new LogLapiMapper
+            {
+                Timestamp = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+                ProductName = index,
+                MachineName = Environment.MachineName,
+                Severity = logEvent.Level.ToString().Replace("Information", "Info"),
+                Message = message.Replace(@"""", "")
+            };
+
+            return lapiMapper;
+        }
+
+        private static void WriteAndFormatPropertiesToSplunk(LogEvent logEvent, LogLapiMapper logLapiMapper, TextWriter output)
+        {
+            output.Write("{\"Timestamp\":\"");
+            output.Write(logLapiMapper.Timestamp + "\"");
+
+            var additionalDataToBeRemoved = new string[] { "SplunkIndex", "ProductCompany", "ProductVersion", "ProcessName" };
+
+            var propertiesFiltered = logEvent.Properties.Where(
+                prop => !additionalDataToBeRemoved.Contains(prop.Key))
+                .ToDictionary(d => d.Key, d => d.Value);
+
+            if (logEvent.Properties.Count != 0)
+                WriteEventProperties(propertiesFiltered, logEvent.Exception, output);
+        }
+
+        private static void WriteDefaultSuffixPropertiesToSplunk(LogLapiMapper logLapiMapper, TextWriter output)
+        {
+            WriteSuffixQuotedJsonString(",\"Message\":", logLapiMapper.Message, output);
+            WriteSuffixQuotedJsonString(",\"MachineName\":", logLapiMapper.MachineName, output);
+            WriteSuffixQuotedJsonString(",\"ProductName\":", logLapiMapper.ProductName, output);
+            WriteSuffixQuotedJsonString(",\"Severity\":", logLapiMapper.Severity, output);
+
+            // Close splunk props
+            output.Write("}");
+        }
+
+        private static void WriteEventProperties(Dictionary<string, LogEventPropertyValue> properties, Exception exception, TextWriter output)
+        {
+            output.Write(",\"AdditionalData\":{");
+
+            var precedingDelimiter = "";
+            foreach (var property in properties)
+            {
+                output.Write(precedingDelimiter);
+                precedingDelimiter = DEFAULT_DELIMITER;
+                WriteLogEventProperty(property.Key, property.Value, output);
+            }
+
+            if (exception != null)
+                WriteException(exception, output);
+
+            output.Write('}');
+        }
+
+        private static void WriteException(Exception exception, TextWriter output)
+        {
+            output.Write(",\"Exception\":{");
+
+            WriteStringProperty("Message", exception.Message, output);
+
+            output.Write(DEFAULT_DELIMITER);
+
+            WriteStringProperty("StackTrace", exception.StackTrace ?? string.Empty, output);
+
+            output.Write('}');
+        }
+
+        private static void WriteLogEventProperty(string nameProperty, LogEventPropertyValue log, TextWriter output)
+        {
+            WriteNameProperty(nameProperty, output);
+            _valueFormatter.Format(log, output);
+        }
+
+        private static void WriteStringProperty(string nameProperty, string str, TextWriter output)
+        {
+            WriteNameProperty(nameProperty, output);
+            JsonValueFormatter.WriteQuotedJsonString(str, output);
+        }
+
+        private static void WriteNameProperty(string nameProperty, TextWriter output)
+        {
+            JsonValueFormatter.WriteQuotedJsonString(nameProperty, output);
+            output.Write(SEPARATOR);
+        }
+
+        private static void WriteSuffixQuotedJsonString(string propertyName, string str, TextWriter output)
+        {
+            if (!string.IsNullOrWhiteSpace(propertyName) && !string.IsNullOrWhiteSpace(str))
+            {
+                output.Write(propertyName);
+                JsonValueFormatter.WriteQuotedJsonString(str, output);
+            }
+        }
+    }
+}

--- a/Serilog.Builder/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/Serilog.Builder/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Configuration;
+using Serilog.Builder.CustomFormatters;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Sinks.Http;
+using Serilog.Sinks.Http.BatchFormatters;
+using System;
+
+namespace Serilog.Builder.Extensions
+{
+    public static class LoggerSinkConfigurationExtensions
+    {
+        public static LoggerConfiguration Lapi(
+            this LoggerSinkConfiguration sinkConfiguration,
+            string requestUri,
+            string index,
+            long? queueLimitBytes = null,
+            long? logEventLimitBytes = null,
+            int? logEventsInBatchLimit = null,
+            long? batchSizeLimitBytes = null,
+            TimeSpan? period = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IHttpClient httpClient = null,
+            IConfiguration configuration = null)
+        {
+            return sinkConfiguration.Http(requestUri: requestUri,
+                                          queueLimitBytes: queueLimitBytes > 0 ? queueLimitBytes : null,
+                                          logEventLimitBytes: logEventLimitBytes,
+                                          logEventsInBatchLimit: logEventsInBatchLimit > 0 ? logEventsInBatchLimit : 1000,
+                                          batchSizeLimitBytes: batchSizeLimitBytes > 0 ? batchSizeLimitBytes : null,
+                                          period: period,
+                                          textFormatter: new LapiJsonFormatter(index),
+                                          batchFormatter: new ArrayBatchFormatter(),
+                                          restrictedToMinimumLevel: restrictedToMinimumLevel,
+                                          httpClient: httpClient,
+                                          configuration: configuration);
+        }
+    }
+}

--- a/Serilog.Builder/ILoggerBuilder.cs
+++ b/Serilog.Builder/ILoggerBuilder.cs
@@ -89,7 +89,7 @@ namespace Serilog.Builder
         LoggerBuilder EnableSplunk(string url, string token);
 
         /// <summary>
-        /// Enable seq
+        /// Setup splunk
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
@@ -100,6 +100,26 @@ namespace Serilog.Builder
         /// </summary>
         /// <returns></returns>
         LoggerBuilder DisableSplunk();
+
+        /// <summary>
+        /// Enable lapi
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        LoggerBuilder EnableLapi(string url, string index);
+
+        /// <summary>
+        /// Setup lapi
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        LoggerBuilder SetupLapi(LapiOptions options);
+
+        /// <summary>
+        /// Disable lapi
+        /// </summary>
+        /// <returns></returns>
+        LoggerBuilder DisableLapi();
 
         /// <summary>
         /// Enable NewRelic

--- a/Serilog.Builder/LoggerBuilder.Lapi.cs
+++ b/Serilog.Builder/LoggerBuilder.Lapi.cs
@@ -1,0 +1,101 @@
+﻿using Serilog.Builder.Extensions;
+using Serilog.Builder.Models;
+using Serilog.Builder.Models.Settings;
+using System;
+
+namespace Serilog.Builder
+{
+    public partial class LoggerBuilder : ILoggerBuilder
+    {
+        /// <summary>
+        /// Build lapi configuration
+        /// </summary>
+        /// <param name="logger"></param>
+        private void BuildLapi(LoggerConfiguration logger)
+        {
+            if (this.OutputConfiguration.Lapi.Enabled == true)
+            {
+                var logLevel = this.OutputConfiguration.Lapi.Options.MinimumLevel
+                    ?? this.OutputConfiguration.MinimumLevel;
+
+                var lapiSettings = this.GetLapiLogSettings();
+
+                logger.WriteTo.Lapi(
+                    requestUri: lapiSettings.ServerURL,
+                    index: lapiSettings.Index,
+                    restrictedToMinimumLevel: logLevel,
+                    queueLimitBytes: lapiSettings.QueueLimitBytes,
+                    logEventsInBatchLimit: lapiSettings.LogEventsInBatchLimit,
+                    batchSizeLimitBytes: lapiSettings.BatchSizeLimitBytes);
+            }
+        }
+
+        /// <summary>
+        /// Enable lapi
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        public LoggerBuilder EnableLapi(string url, string index)
+        {
+            return this.SetupLapi(new LapiOptions
+            {
+                Enabled = true,
+                Url = url,
+                Index = index
+            });
+        }
+
+        /// <summary>
+        /// Setup lapi
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public LoggerBuilder SetupLapi(LapiOptions options)
+        {
+            this.OutputConfiguration.Lapi.Options = options
+                ?? throw new ArgumentNullException(nameof(options));
+
+            if (string.IsNullOrWhiteSpace(options.Url) == true && options.Enabled == true)
+            {
+                throw new ArgumentNullException(nameof(options.Url));
+            }
+
+            this.OutputConfiguration.Lapi.Enabled = options.Enabled;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Disable lapi
+        /// </summary>
+        /// <returns></returns>
+        public LoggerBuilder DisableLapi()
+        {
+            this.OutputConfiguration.Lapi.Enabled = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Get Lapi log settings
+        /// </summary>
+        /// <returns></returns>
+        private LapiLogSettings GetLapiLogSettings()
+        {
+            var lapiLogSettings = new LapiLogSettings
+            {
+                Application = this.OutputConfiguration.Lapi.Options.Application,
+                Index = this.OutputConfiguration.Lapi.Options.Index,
+                ProcessName = this.OutputConfiguration.Lapi.Options.ProcessName,
+                ProductCompany = this.OutputConfiguration.Lapi.Options.Company,
+                ProductVersion = this.OutputConfiguration.Lapi.Options.ProductVersion,
+                ServerURL = this.OutputConfiguration.Lapi.Options.Url,
+                SourceType = this.OutputConfiguration.Lapi.Options.SourceType,
+                QueueLimitBytes = this.OutputConfiguration.Lapi.Options.QueueLimitBytes,
+                BatchSizeLimitBytes = this.OutputConfiguration.Lapi.Options.BatchSizeLimitBytes,
+                LogEventsInBatchLimit = this.OutputConfiguration.Lapi.Options.LogEventsInBatchLimit
+            };
+
+            return lapiLogSettings;
+        }
+    }
+}

--- a/Serilog.Builder/LoggerBuilder.Splunk.cs
+++ b/Serilog.Builder/LoggerBuilder.Splunk.cs
@@ -57,7 +57,7 @@ namespace Serilog.Builder
         }
 
         /// <summary>
-        /// Setup seq
+        /// Setup splunk
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>

--- a/Serilog.Builder/LoggerBuilder.cs
+++ b/Serilog.Builder/LoggerBuilder.cs
@@ -95,6 +95,7 @@ namespace Serilog.Builder
             return this.DisableConsole()
                        .DisableSeq()
                        .DisableSplunk()
+                       .DisableLapi()
                        .DisableNewRelic()
                        .DisableDataDog();
         }
@@ -237,6 +238,7 @@ namespace Serilog.Builder
             this.BuildSeq(logger);
             this.BuildNewRelic(logger);
             this.BuildSplunk(logger);
+            this.BuildLapi(logger);
             this.BuildDataDog(logger);
 
             logger.Destructure.ToMaximumDepth(15);

--- a/Serilog.Builder/LoggerInitialize.cs
+++ b/Serilog.Builder/LoggerInitialize.cs
@@ -23,6 +23,7 @@ namespace Serilog.Builder
                 .SetupSeq(loggerOptions.Seq)
                 .SetupSplunk(loggerOptions.Splunk)
                 .SetupNewRelic(loggerOptions.NewRelic)
+                .SetupLapi(loggerOptions.Lapi)
                 .SetupDataDog(loggerOptions.DataDog)
                 .BuildLogger();
 

--- a/Serilog.Builder/Models/LapiOptions.cs
+++ b/Serilog.Builder/Models/LapiOptions.cs
@@ -1,0 +1,67 @@
+﻿using Serilog.Events;
+
+namespace Serilog.Builder.Models
+{
+    public class LapiOptions
+    {
+        /// <summary>
+        /// Set if Lapi is enabled
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Minimum Level
+        /// </summary>
+        public LogEventLevel? MinimumLevel { get; set; }
+
+        /// <summary>
+        /// Lapi index
+        /// </summary>
+        public string Index { get; set; }
+
+        /// <summary>
+        /// Lapi Application
+        /// </summary>
+        public string Application { get; set; }
+
+        /// <summary>
+        /// Process name
+        /// </summary>
+        public string ProcessName { get; set; }
+
+        /// <summary>
+        /// Company
+        /// </summary>
+        public string Company { get; set; }
+
+        /// <summary>
+        /// Product version
+        /// </summary>
+        public string ProductVersion { get; set; }
+
+        /// <summary>
+        /// Server Url
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Source type
+        /// </summary>
+        public string SourceType { get; set; }
+
+        /// <summary>
+        /// Batch size limit bytes
+        /// </summary>
+        public long? BatchSizeLimitBytes { get; set; }
+
+        /// <summary>
+        /// Log events in batch limit
+        /// </summary>
+        public int? LogEventsInBatchLimit { get; set; }
+
+        /// <summary>
+        /// Queue limit bytes
+        /// </summary>
+        public long? QueueLimitBytes { get; set; }
+    }
+}

--- a/Serilog.Builder/Models/LoggerOptions.cs
+++ b/Serilog.Builder/Models/LoggerOptions.cs
@@ -36,6 +36,11 @@
         public SplunkOptions Splunk { get; set; } = new SplunkOptions();
 
         /// <summary>
+        /// Lapi
+        /// </summary>
+        public LapiOptions Lapi { get; set; } = new LapiOptions();
+
+        /// <summary>
         /// NewRelic
         /// </summary>
         public NewRelicOptions NewRelic { get; set; } = new NewRelicOptions();

--- a/Serilog.Builder/Models/Mappers/LogLapiMapper.cs
+++ b/Serilog.Builder/Models/Mappers/LogLapiMapper.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+
+namespace Serilog.Builder.Models.Mappers
+{
+    [JsonObject]
+    public class LogLapiMapper
+    {
+        [JsonProperty(PropertyName = "timestamp")]
+        public string Timestamp { get; set; }
+
+        [JsonProperty(PropertyName = "machinename")]
+        public string MachineName { get; set; }
+
+        [JsonProperty(PropertyName = "severity")]
+        public string Severity { get; set; }
+
+        [JsonProperty(PropertyName = "productname")]
+        public string ProductName { get; set; }
+
+        [JsonProperty(PropertyName = "message")]
+        public string Message { get; set; }
+
+        [JsonProperty(PropertyName = "event")]
+        public object Event { get; set; }
+    }
+}

--- a/Serilog.Builder/Models/OutputConfiguration.cs
+++ b/Serilog.Builder/Models/OutputConfiguration.cs
@@ -46,6 +46,11 @@ namespace Serilog.Builder.Models
         public Output<DataDogOptions> DataDog { get; set; }
 
         /// <summary>
+        /// Lapi
+        /// </summary>
+        public Output<LapiOptions> Lapi { get; set; }
+
+        /// <summary>
         /// Minimum level
         /// </summary>
         public LogEventLevel MinimumLevel { get; set; }
@@ -63,6 +68,7 @@ namespace Serilog.Builder.Models
             this.Console = new Output<ConsoleOptions>();
             this.Seq = new Output<SeqOptions>();
             this.Splunk = new Output<SplunkOptions>();
+            this.Lapi = new Output<LapiOptions>();
             this.NewRelic = new Output<NewRelicOptions>();
             this.DataDog = new Output<DataDogOptions>();
             this.OverrideMinimumLevel = new Dictionary<string, LogEventLevel>();

--- a/Serilog.Builder/Models/Settings/LapiLogSettings.cs
+++ b/Serilog.Builder/Models/Settings/LapiLogSettings.cs
@@ -1,0 +1,27 @@
+﻿namespace Serilog.Builder.Models.Settings
+{
+    public class LapiLogSettings
+    {
+        public string ServerURL { get; set; }
+
+        public string Index { get; set; }
+
+        public string SourceType { get; set; }
+
+        public string ProductCompany { get; set; }
+
+        public string ProductVersion { get; set; }
+
+        public string ProcessName { get; set; }
+
+        public string Application { get; set; }
+
+        public long? BatchSizeLimitBytes { get; set; }
+
+        public int? LogEventsInBatchLimit { get; set; }
+
+        public long? QueueLimitBytes { get; set; }
+
+        public long? LogEventLimitBytes { get; set; }
+    }
+}

--- a/Serilog.Builder/Serilog.Builder.csproj
+++ b/Serilog.Builder/Serilog.Builder.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.3.5" />
+    <PackageReference Include="Serilog.Sinks.Http" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.NewRelic.Logs" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.0" />
     <PackageReference Include="Serilog.Sinks.Splunk" Version="3.7.0" />


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/l2JejCMvqWHTKyfxm/giphy.gif)

### Status

READY 

### Whats?

Adds new configuration logger for Lapi.

### Why?

WalletsApi is losing logs from splunk and after a little analysis, the team informed us that we could be losing logs because we were sending logs direct to splunk. The first suggestion was change the way that logs are sent to Logger Api (LAPI).

### How?

Just adds new configuration to log through Sink.Http and make all configuration methods available.

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [x] Implements unit tests
- [x] Is there appropriate logging included?
- [x] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [x] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
